### PR TITLE
Feature: make adf sources and models work in bigquery

### DIFF
--- a/macros/adf_pipelines_name.sql
+++ b/macros/adf_pipelines_name.sql
@@ -1,0 +1,14 @@
+{% macro adf_pipelines_name(column) -%}
+    {{ return(adapter.dispatch('adf_pipelines_name')(column)) }}
+{%- endmacro %}
+
+
+{% macro default__adf_pipelines_name(column) -%}
+   {{ column }}
+{%- endmacro %}
+
+{% macro bigquery__adf_pipelines_name(column) -%}
+    {% if column ==  'pipelines.pipelineReference.referenceName' -%}
+        {{ 'pipelineReference.referenceName' }}
+    {% endif %}
+{%- endmacro %} 

--- a/models/staging/adf_sources/stg_dag_adf.sql
+++ b/models/staging/adf_sources/stg_dag_adf.sql
@@ -16,7 +16,7 @@ triggers_renamed as (
             when properties.typeProperties.recurrence.frequency  = 'Month' then 'monthly'
             when properties.typeProperties.recurrence.frequency  = 'Minute' then 'minutely'
         end as dag_frequency
-        ,cast(properties.typeProperties.recurrence.schedule as varchar(255)) as timetable_description
+        ,{{ cast_as_string('properties.typeProperties.recurrence.schedule') }} as timetable_description
         ,properties.typeProperties.recurrence.frequency as adf_frequency
         ,properties.typeProperties.recurrence.startTime as start_time
         , case 
@@ -28,7 +28,7 @@ triggers_renamed as (
             else 'true'
             end as is_paused
         ,properties.runtimeState
-        ,pipelines.pipelineReference.referenceName as pipeline_name
+        ,{{adf_pipelines_name('pipelines.pipelineReference.referenceName') }} as pipeline_name
         
     from exploded_by_pipeline
 ),


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

This PR aims to create macros that make adf sources works in bigquery and adapt models to work there too.

The macro created by this PR is adf_pipelines_name.sql. This macro is necessary beacause when we make a lateral view from properties.pipelines (a column of adf_triggers), the output is differente between bigquery and databricks. 

### Why

This is necessary because the models as they are today does not work in others DWs

### Known limitations

This changes just works in bigquery and databricks. Snowflake target hasn't been tested yet