### PR TITLE
Adding a marcro to name the day_of_week on each platform.

### DIFF
--- a/macros/de_para_dias_da_semana.sql
+++ b/macros/de_para_dias_da_semana.sql
@@ -1,0 +1,39 @@
+{% macro de_para_dias_da_semana(column) %}
+    {{ return(adapter.dispatch('de_para_dias_da_semana')(column)) }}
+{%- endmacro %}
+
+{% macro databricks__de_para_dias_da_semana(column) %}
+            case
+                when {{ column }} = 1 then 'Domingo'
+                when {{ column }} = 2 then 'Segunda-feira'
+                when {{ column }} = 3 then 'Terça-feira'
+                when {{ column }} = 4 then 'Quarta-feira'
+                when {{ column }} = 5 then 'Quinta-feira'
+                when {{ column }} = 6 then 'Sexta'
+                when {{ column }} = 7 then 'Sábado'
+            end as nome_do_dia
+{% endmacro %}
+
+{% macro snowflake__de_para_dias_da_semana(column) %}
+            case
+                when {{ column }} = 0 then 'Domingo'
+                when {{ column }} = 1 then 'Segunda-feira'
+                when {{ column }} = 2 then 'Terça-feira'
+                when {{ column }} = 3 then 'Quarta-feira'
+                when {{ column }} = 4 then 'Quinta-feira'
+                when {{ column }} = 5 then 'Sexta'
+                when {{ column }} = 6 then 'Sábado'
+            end as nome_do_dia
+{% endmacro %}
+
+{% macro bigquery__de_para_dias_da_semana(column) %}
+            case
+                when {{ column }} = 1 then 'Domingo'
+                when {{ column }} = 2 then 'Segunda-feira'
+                when {{ column }} = 3 then 'Terça-feira'
+                when {{ column }} = 4 then 'Quarta-feira'
+                when {{ column }} = 5 then 'Quinta-feira'
+                when {{ column }} = 6 then 'Sexta'
+                when {{ column }} = 7 then 'Sábado'
+            end as nome_do_dia
+{% endmacro %}

--- a/models/calendar/dim_dag_monitoring_dates.sql
+++ b/models/calendar/dim_dag_monitoring_dates.sql
@@ -36,15 +36,7 @@ with
     , days_named as (
         select
             *
-            , case
-                when dia_da_semana = 1 then 'Segunda-feira'
-                when dia_da_semana = 2 then 'Terça-feira'
-                when dia_da_semana = 3 then 'Quarta-feira'
-                when dia_da_semana = 4 then 'Quinta-feira'
-                when dia_da_semana = 5 then 'Sexta-feira'
-                when dia_da_semana = 6 then 'Sábado'
-                when dia_da_semana = 0 then 'Domingo'
-            end as nome_do_dia
+            , {{ de_para_dias_da_semana('dia_da_semana') }}
             , case
                 when mes = 1 then 'Janeiro'
                 when mes = 2 then 'Fevereiro'


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ x ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ x ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

This PR aims to add a macro to sort the names of the days of the week according to the data platform.

### Why

Before this change in databricks for example, the day_of_week (sunday) was not being displayed.

### Known limitations

[TODO or N/A]